### PR TITLE
use dot as separator for easier addressing in logback configuration

### DIFF
--- a/com.swookiee.runtime.core/src/main/java/com/swookiee/core/internal/logging/LogReaderServiceTracker.java
+++ b/com.swookiee.runtime.core/src/main/java/com/swookiee/core/internal/logging/LogReaderServiceTracker.java
@@ -53,7 +53,7 @@ public class LogReaderServiceTracker implements ServiceTrackerCustomizer<LogRead
         @Override
         public void logged(final LogEntry entry) {
 
-            final Logger logger = LoggerFactory.getLogger("Bundle:" + entry.getBundle().getSymbolicName());
+            final Logger logger = LoggerFactory.getLogger("Bundle." + entry.getBundle().getSymbolicName());
             // Marker marker = MarkerFactory.getMarker(entry.getBundle().getSymbolicName());
 
             switch (entry.getLevel()) {


### PR DESCRIPTION
This changes logger names relayed from the OSGi logger from "Bundle:com.whatever" to "bundle.com.whatever" (note dot vs colon). As a result, it is easier to configure log levels for all OSGi internal messages at once.
