### PR TITLE
allow to wait for debugger on startup

### DIFF
--- a/com.swookiee.runtime/pom.xml
+++ b/com.swookiee.runtime/pom.xml
@@ -16,6 +16,9 @@
 
     <properties>
         <dropin.path>${project.build.directory}/dropins</dropin.path>
+
+        <!-- If set to "y", this will cause swookiee to wait for a connected remote debugging session -->
+        <debug.suspend>n</debug.suspend>
     </properties>
 
     <dependencies>
@@ -56,7 +59,7 @@
                         <argument>-Dosgi.compatibility.bootdelegation=true</argument>
                         <argument>-Dfelix.fileinstall.dir=${dropin.path}</argument>
                         <argument>-Xdebug</argument>
-                        <argument>-Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n</argument>
+                        <argument>-Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=${debug.suspend}</argument>
                         <argument>-jar</argument>
                         <argument>${project.build.directory}/runtime/plugins/org.eclipse.osgi_3.9.1.v20140110-1610.jar</argument>
                         <argument>-console</argument>


### PR DESCRIPTION
To use, start with mvn exec:exec -Ddebug.suspend=y
