### PR TITLE
provide better error message on invalid configuration field types

### DIFF
--- a/com.swookiee.runtime.util.test/src/main/groovy/com/swookiee/runtime/core/configuration/ConfigurationUtilsTest.groovy
+++ b/com.swookiee.runtime.util.test/src/main/groovy/com/swookiee/runtime/core/configuration/ConfigurationUtilsTest.groovy
@@ -4,11 +4,15 @@ import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
+import java.io.IOException;
+import java.util.HashMap;
+
 import org.junit.Test
 import org.osgi.service.cm.Configuration
 import org.osgi.service.cm.ConfigurationAdmin
 
 import com.swookiee.runtime.util.configuration.ConfigurationUtils
+import com.swookiee.runtime.util.test.Helpers
 
 public class ConfigurationUtilsTest {
 
@@ -23,6 +27,24 @@ public class ConfigurationUtilsTest {
     @Test
     void 'test that null values dont throw a NPE'(){
         ConfigurationUtils.applyConfiguration(null, null, null)
+    }
+
+    @Test
+    void "gives a helpful error message when trying to apply non-simple types"() {
+        try {
+            ConfigurationUtils.applyConfigurationElements(
+                    [ getConfiguration : { def pid ->
+                            [ update : { Dictionary properties ->
+                                    fail("should not update")
+                                }
+                            ] as Configuration
+                        }] as ConfigurationAdmin, new Helpers.ConfigWrapper());
+            fail("should have thrown Exception")
+        } catch (RuntimeException e) {
+            assertThat(e.getCause(), isA(java.lang.IllegalArgumentException))
+            assertThat e.getCause().getMessage(), containsString('OSGi accepts only simple types')
+            assertThat e.getCause().getMessage(), containsString('aMap')
+        }
     }
 
     def getConfigAdmin(Closure<?> closure){

--- a/com.swookiee.runtime.util.test/src/main/java/com/swookiee/runtime/util/test/Helpers.java
+++ b/com.swookiee.runtime.util.test/src/main/java/com/swookiee/runtime/util/test/Helpers.java
@@ -1,0 +1,20 @@
+package com.swookiee.runtime.util.test;
+
+import java.util.HashMap;
+
+/* in here because creating them on the groovy side creates additional fields that throw off the algorithm */
+public class Helpers {
+
+	public static class ConfigWrapper {
+		public PojoWithNonPrimitiveField offender = new PojoWithNonPrimitiveField();
+	}
+	
+    public static class PojoWithNonPrimitiveField implements com.swookiee.runtime.util.configuration.Configuration {
+		@Override
+		public String getPid() {
+			return "whatever";
+		}
+		
+        public HashMap<String, String> aMap = new HashMap<String, String>();
+    }
+}


### PR DESCRIPTION
The OSGi message just says "IllegalArgumentException: [type]". With this, the exception contains the PID of the configuration that failed and the key for the invalid value. Helps with debugging.
