### PR TITLE
include jersey's servlet 3.0 container implementation

### DIFF
--- a/com.swookiee.runtime.product/com.swookiee.runtime.product
+++ b/com.swookiee.runtime.product/com.swookiee.runtime.product
@@ -109,6 +109,7 @@
       <plugin id="org.glassfish.hk2.utils"/>
       <plugin id="org.glassfish.jersey.bundles.repackaged.jersey-guava"/>
       <plugin id="org.glassfish.jersey.containers.jersey-container-servlet-core"/>
+      <plugin id="org.glassfish.jersey.containers.jersey-container-servlet"/>
       <plugin id="org.glassfish.jersey.core.jersey-client"/>
       <plugin id="org.glassfish.jersey.core.jersey-common"/>
       <plugin id="org.glassfish.jersey.core.jersey-server"/>
@@ -195,6 +196,7 @@
       <plugin id="org.glassfish.hk2.osgi-resource-locator" autoStart="true" startLevel="0" />
       <plugin id="org.glassfish.hk2.utils" autoStart="true" startLevel="0" />
       <plugin id="org.glassfish.jersey.bundles.repackaged.jersey-guava" autoStart="true" startLevel="0" />
+      <plugin id="org.glassfish.jersey.containers.jersey-container-servlet" autoStart="true" startLevel="0" />
       <plugin id="org.glassfish.jersey.containers.jersey-container-servlet-core" autoStart="true" startLevel="0" />
       <plugin id="org.glassfish.jersey.core.jersey-client" autoStart="true" startLevel="0" />
       <plugin id="org.glassfish.jersey.core.jersey-common" autoStart="true" startLevel="3" />

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>${jersey.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-metainf-services</artifactId>
             <version>${jersey.version}</version>


### PR DESCRIPTION
The jersey-container-servlet-core jar only provides a basic servlet 2.x container.
By adding jersey-container-servlet jar, we gain access to the features of a
servlet 3.x container.
